### PR TITLE
Disable access to the chip via the debug port.

### DIFF
--- a/dfu/sdk_config.h
+++ b/dfu/sdk_config.h
@@ -225,7 +225,7 @@
 // <i> for more details.
 
 #ifndef NRF_BL_DEBUG_PORT_DISABLE
-#define NRF_BL_DEBUG_PORT_DISABLE 0
+#define NRF_BL_DEBUG_PORT_DISABLE 1
 #endif
 
 // <o> NRF_BL_FW_COPY_PROGRESS_STORE_STEP - Number of pages copied after which progress in the settings page is updated. 


### PR DESCRIPTION
[Disable access to the chip via the debug port.](https://github.com/OneKeyHQ/bluetooth-firmware-pro/commit/ab93bb67ef9cdefdc04ce9085d7f4b4754e66c86)