### PR TITLE
Update CI Config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,14 @@ jobs:
     name: "build"
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
+      - name: Configure Fast APT Mirror
+        uses: vegardit/fast-apt-mirror.sh@v1
+        with: # the following parameters are listed with their action default values and are optional
+          healthchecks:  20 # Number of mirrors from the mirrors list to check for availability and up-to-dateness
+          speedtests:    10 # Maximum number of healthy mirrors to test for speed
+          parallel:       2 # Number of parallel speed tests
+          sample-size: 1024 # Number of kilobytes to download during the speed from each mirror
+          sample-time:    3 # Maximum number of seconds within the sample download from a mirror must finish
 
       - name: Install Dependencies
         run: |
@@ -30,6 +36,9 @@ jobs:
             tar -xf arm-gnu-toolchain-12.2.rel1-aarch64-arm-none-eabi.tar.xz --strip-components=1 -C gcc-arm-none-eabi-12.2.rel1
           fi
 
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        
       - name: Populate vars
         id: vars
         run: |


### PR DESCRIPTION
Microsoft Azure mirror has stability issues for a while, causing builds to fail, this commit adds `fast-apt-mirror.sh` to select mirror automatically.

Script source:
https://github.com/vegardit/fast-apt-mirror.sh/blob/v1/fast-apt-mirror.sh

More details about the mirror issue:
https://github.com/actions/runner-images/issues?q=is%3Aissue+azure.archive.ubuntu.com