### PR TITLE
Add version number to the firmware header. && bump version to 2.3.3

### DIFF
--- a/app/firmware_config.h
+++ b/app/firmware_config.h
@@ -11,7 +11,7 @@
     0xEEBBEE /**< DUMMY Organisation Unique ID. Will be passed to Device Information Service. You shall use the \
                 Organisation Unique ID relevant for your Company */
 #define HW_REVISION "1.0.0"
-#define FW_REVISION "2.3.2"
+#define FW_REVISION "2.3.3"
 #define SW_REVISION "s132_nrf52_7.0.1"
 #define BT_REVISION "1.0.1"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 固件版本号已更新至“2.3.3”，反映了固件功能或特性的潜在增强。
  - 引入了版本偏移量常量，增强了生成二进制文件时的版本信息处理。

- **改进**
  - 更新了生成二进制文件的功能，以从固件配置头文件中读取并解析版本信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->